### PR TITLE
Rewrite util money helpers in rust

### DIFF
--- a/src/base58.rs
+++ b/src/base58.rs
@@ -1,0 +1,126 @@
+// Base58 encoding/decoding implementation inspired by bitcoin-cpp v0.1.5
+// Rewritten in Rust.
+
+const ALPHABET: &[u8; 58] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+/// Encode bytes as a base58 string.
+pub fn encode_base58(data: &[u8]) -> String {
+    // Count leading zeros.
+    let zeros = data.iter().take_while(|b| **b == 0).count();
+    // Allocate enough space in big-endian base58 representation.
+    let mut digits = vec![0u8; data.len() * 138 / 100 + 1];
+    let mut length = 0usize;
+
+    for byte in &data[zeros..] {
+        let mut carry = *byte as u32;
+        let mut i = 0usize;
+        for d in digits[..length].iter_mut().rev() {
+            carry += (*d as u32) << 8;
+            *d = (carry % 58) as u8;
+            carry /= 58;
+            i += 1;
+        }
+        while carry > 0 {
+            digits[length] = (carry % 58) as u8;
+            length += 1;
+            carry /= 58;
+        }
+    }
+
+    let mut result = String::with_capacity(zeros + length);
+    for _ in 0..zeros {
+        result.push('1');
+    }
+    for d in digits[..length].iter().rev() {
+        result.push(ALPHABET[*d as usize] as char);
+    }
+    result
+}
+
+/// Decode a base58 string into bytes. Returns `None` on invalid input.
+pub fn decode_base58(s: &str) -> Option<Vec<u8>> {
+    let s = s.trim_start();
+    if s.is_empty() {
+        return Some(Vec::new());
+    }
+    let bytes = s.as_bytes();
+    let zeros = bytes.iter().take_while(|&&b| b == ALPHABET[0]).count();
+    let mut b256 = vec![0u8; s.len() * 733 / 1000 + 1];
+    let mut length = 0usize;
+
+    for &ch in &bytes[zeros..] {
+        let val = match ALPHABET.iter().position(|&c| c == ch) {
+            Some(v) => v as u32,
+            None => return None,
+        };
+        let mut carry = val;
+        for d in b256[..length].iter_mut().rev() {
+            carry += (*d as u32) * 58;
+            *d = (carry % 256) as u8;
+            carry /= 256;
+        }
+        while carry > 0 {
+            b256[length] = (carry % 256) as u8;
+            length += 1;
+            carry /= 256;
+        }
+    }
+
+    let mut result = Vec::with_capacity(zeros + length);
+    result.extend(std::iter::repeat(0u8).take(zeros));
+    for b in b256[..length].iter().rev() {
+        result.push(*b);
+    }
+    Some(result)
+}
+
+/// Compute double SHA256 (sha256d) of the data.
+fn sha256d(data: &[u8]) -> [u8; 32] {
+    use bitcoin::hashes::{sha256d, Hash};
+    let hash = sha256d::Hash::hash(data);
+    hash.into_inner()
+}
+
+/// Encode data in base58 with a 4-byte checksum.
+pub fn encode_base58_check(data: &[u8]) -> String {
+    let checksum = sha256d(data);
+    let mut extended = Vec::with_capacity(data.len() + 4);
+    extended.extend_from_slice(data);
+    extended.extend_from_slice(&checksum[0..4]);
+    encode_base58(&extended)
+}
+
+/// Decode base58 string with checksum verification.
+/// Returns `None` if decoding fails or checksum mismatch occurs.
+pub fn decode_base58_check(s: &str) -> Option<Vec<u8>> {
+    let mut data = decode_base58(s)?;
+    if data.len() < 4 {
+        return None;
+    }
+    let checksum = sha256d(&data[..data.len() - 4]);
+    if checksum[0..4] != data[data.len() - 4..] {
+        return None;
+    }
+    data.truncate(data.len() - 4);
+    Some(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_hello_world() {
+        let encoded = encode_base58(b"hello world");
+        assert_eq!(encoded, "StV1DL6CwTryKyV");
+    }
+
+    #[test]
+    fn roundtrip_base58_check() {
+        let data = b"rust-base58";
+        let enc = encode_base58_check(data);
+        let dec = decode_base58_check(&enc).expect("decode failed");
+        assert_eq!(dec, data);
+    }
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,9 @@ use bitcoin::blockdata::constants::genesis_block;
 use bitcoin::network::constants::Network;
 use bitcoin::consensus::encode::serialize_hex;
 
+mod base58;
+mod util;
+
 fn genesis_hex() -> String {
     let genesis = genesis_block(Network::Bitcoin);
     serialize_hex(&genesis)

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,98 @@
+pub const COIN: i64 = 100_000_000;
+pub const CENT: i64 = 1_000_000;
+
+/// Format satoshi amounts into a human readable string with two decimal places
+/// and comma separators. Negative amounts are supported. If `plus` is true,
+/// positive values are prefixed with `+`.
+pub fn format_money(mut n: i64, plus: bool) -> String {
+    n /= CENT;
+    let negative = n < 0;
+    if negative { n = -n; }
+    let mut s = format!("{}.{:02}", n / 100, n % 100);
+    let mut i = 6usize;
+    while i < s.len() {
+        if s.as_bytes()[s.len() - i - 1].is_ascii_digit() {
+            s.insert(s.len() - i, ',');
+        }
+        i += 4;
+    }
+    if negative {
+        s.insert(0, '-');
+    } else if plus && n > 0 {
+        s.insert(0, '+');
+    }
+    s
+}
+
+/// Parse a decimal string into a satoshi amount. Commas are ignored and up to
+/// two fractional digits are supported. Returns `None` on parse failure or
+/// overflow.
+pub fn parse_money(s: &str) -> Option<i64> {
+    let s = s.trim();
+    if s.is_empty() { return None; }
+    let mut chars = s.chars().peekable();
+    let mut whole = String::new();
+    while let Some(&c) = chars.peek() {
+        if c == ',' {
+            chars.next();
+            continue;
+        }
+        if c == '.' || c.is_whitespace() {
+            break;
+        }
+        if !c.is_ascii_digit() {
+            return None;
+        }
+        whole.push(c);
+        chars.next();
+    }
+    let mut cents: i64 = 0;
+    if let Some('.') = chars.peek() {
+        chars.next();
+        if let Some(c1) = chars.next() {
+            if !c1.is_ascii_digit() { return None; }
+            cents = 10 * (c1.to_digit(10).unwrap() as i64);
+            if let Some(&c2) = chars.peek() {
+                if c2.is_ascii_digit() {
+                    cents += c2.to_digit(10).unwrap() as i64;
+                    chars.next();
+                }
+            }
+        }
+    }
+    while let Some(&c) = chars.peek() {
+        if !c.is_whitespace() { return None; }
+        chars.next();
+    }
+    if whole.len() > 14 { return None; }
+    let n_whole: i64 = whole.parse().ok()?;
+    let pre = n_whole.checked_mul(100)?.checked_add(cents)?;
+    let value = pre.checked_mul(CENT)?;
+    if value / CENT != pre { return None; }
+    if value / COIN != n_whole { return None; }
+    Some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_money_simple() {
+        assert_eq!(format_money(COIN, false), "1.00");
+        assert_eq!(format_money(-COIN, false), "-1.00");
+    }
+
+    #[test]
+    fn test_format_money_commas() {
+        assert_eq!(format_money(123_456_789 * COIN, false), "123,456,789.00");
+    }
+
+    #[test]
+    fn test_parse_money() {
+        assert_eq!(parse_money("1.00"), Some(COIN));
+        assert_eq!(parse_money("0.01"), Some(CENT));
+        assert_eq!(parse_money("123,456,789.00"), Some(123_456_789 * COIN));
+        assert_eq!(parse_money("bogus"), None);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `format_money` and `parse_money` inspired by Bitcoin v0.1.5
- expose new module via `util.rs`
- include unit tests
- reference the module from `main.rs`

## Testing
- `cargo fmt` *(skipped: no network access)*
- `cargo check` *(skipped: no network access)*
- `cargo test` *(skipped: no network access)*
- `git status --short`
