### PR TITLE
Add block height reporting option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,13 +12,54 @@ fn genesis_hex() -> String {
     serialize_hex(&genesis)
 }
 
+/// Command line arguments after parsing.
+#[derive(Debug, PartialEq)]
+struct Args {
+    /// Optional peer address to connect to.
+    addr: Option<String>,
+    /// Whether to display the synced block height.
+    show_height: bool,
+}
+
+/// Parse command line arguments. The first non-flag argument is treated as the
+/// peer address. Currently only a single `--height` flag is supported.
+fn parse_args(args: &[String]) -> Args {
+    let mut show_height = false;
+    let mut addr = None;
+    for arg in args.iter().skip(1) {
+        if arg == "--height" {
+            show_height = true;
+        } else if addr.is_none() {
+            addr = Some(arg.clone());
+        }
+    }
+    Args { addr, show_height }
+}
+
+/// Placeholder for future header synchronization. Returns the current best
+/// height, which is zero for now.
+fn sync_headers(_peer: &mut p2p::Peer) -> Result<u64, Box<dyn std::error::Error>> {
+    // TODO: implement real header synchronization.
+    Ok(0)
+}
+
 fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    if let Some(addr) = args.get(1) {
+    let raw_args: Vec<String> = std::env::args().collect();
+    let args = parse_args(&raw_args);
+
+    if let Some(addr) = args.addr.as_ref() {
         println!("Connecting to {}...", addr);
         match p2p::Peer::connect(addr) {
             Ok(mut peer) => match peer.handshake() {
-                Ok(_) => println!("Handshake with {} successful", addr),
+                Ok(_) => {
+                    println!("Handshake with {} successful", addr);
+                    if args.show_height {
+                        match sync_headers(&mut peer) {
+                            Ok(height) => println!("Current block height: {}", height),
+                            Err(e) => eprintln!("Header sync failed: {}", e),
+                        }
+                    }
+                }
                 Err(e) => eprintln!("Handshake failed: {}", e),
             },
             Err(e) => eprintln!("Connection error: {}", e),
@@ -52,5 +93,29 @@ mod tests {
         let genesis = genesis_block(Network::Bitcoin);
         assert_eq!(genesis.header.merkle_root.to_hex(),
             "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    }
+
+    #[test]
+    fn parse_args_height_and_addr() {
+        let args = vec!["prog".into(), "--height".into(), "127.0.0.1".into()];
+        let parsed = parse_args(&args);
+        assert_eq!(parsed.show_height, true);
+        assert_eq!(parsed.addr, Some("127.0.0.1".into()));
+    }
+
+    #[test]
+    fn parse_args_addr_only() {
+        let args = vec!["prog".into(), "127.0.0.1".into()];
+        let parsed = parse_args(&args);
+        assert_eq!(parsed.show_height, false);
+        assert_eq!(parsed.addr, Some("127.0.0.1".into()));
+    }
+
+    #[test]
+    fn parse_args_no_options() {
+        let args = vec!["prog".into()];
+        let parsed = parse_args(&args);
+        assert_eq!(parsed.show_height, false);
+        assert_eq!(parsed.addr, None);
     }
 }


### PR DESCRIPTION
## Summary
- implement `--height` flag parsing
- stub header synchronization
- print block height after syncing when requested
- test argument parsing

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' is not installed)*
- `cargo check` *(fails to fetch crates index)*
- `git status --short`
