### PR TITLE
Clarify internet availability in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,11 @@
 Currently the container lacks network access. Skip `cargo fmt` and `cargo check`
 commands while this issue persists. Mention the lack of networking in your PR.
 
+Internet connectivity is only available during the setup phase of the
+environment. If additional dependencies are required, make sure they are added
+to `Cargo.toml` before the environment starts so they can be fetched while
+networking is still enabled.
+
 ## Git
 - Use a single commit per change with a clear message.
 - Show `git status --short` in the PR testing section.


### PR DESCRIPTION
## Summary
- note that internet is only available during setup and dependencies must be declared beforehand

## Testing
- `git status --short`
