### PR TITLE
Add help flag and argument validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ target/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+Cargo.lock


### PR DESCRIPTION
## Summary
- support `-h`/`--help` in argument parser
- print usage and exit when help or invalid options are supplied
- test help output and invalid options
- remove `Cargo.lock` and ignore it

## Testing
- `cargo fmt -- src/main.rs`
- `cargo check` *(failed: could not download crates)*
- `cargo test` *(failed: could not download crates)*
- `git status --short`
