### PR TITLE
Switch to clap for CLI parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ bitcoin = "0.32.6"
 rand = "0.8"
 tokio = { version = "1", features = ["net", "rt-multi-thread", "io-util", "macros"] }
 base58ck = "0.1.0"
+clap = { version = "4.5.1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- replace custom argument parsing with `clap`
- update dependencies to include `clap`

## Testing
- `cargo fmt`
- `cargo check --offline` *(fails: no matching package named `clap` found)*
- `git status --short`
